### PR TITLE
fix(demo): pin the HF Space to a released version and add a deploy target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docker-build docker-build-demo docker-run docker-run-demo docker-push serve app export-paper-onnx export-blinkcnn push-model push-model-card push-corpus pull-corpus push-dataset-card help install dev install-docs train preprocess fix lint type-check test test-full docs docs-serve docs-deploy check check-full check-ci clean \
+.PHONY: docker-build docker-build-demo docker-run docker-run-demo docker-push serve app export-paper-onnx export-blinkcnn push-model push-model-card push-space push-corpus pull-corpus push-dataset-card help install dev install-docs train preprocess fix lint type-check test test-full docs docs-serve docs-deploy check check-full check-ci clean \
         export-blinkcnn-onnx compare-models compare-shipped score-models benchmark-runtime benchmark-streaming \
         webcam video-demo \
         preprocess-talkingface preprocess-rn15 preprocess-rn30 \
@@ -28,6 +28,7 @@ help:
 	@echo "Docs:                docs-serve | docs-deploy"
 	@echo "Build a corpus:      preprocess-<db> | preprocess-all"
 	@echo "Artifacts (HF):      push-<db> | pull-<db> | push-all | pull-all | push-hf-card"
+	@echo "Deploy the demo:     push-space (then factory-reboot to change python_version)"
 	@echo "Training:            train-joint | train-blink-presence | train-eye-state"
 	@echo "Shipped models:      train-cnn | train-lint | train-linmult |"
 	@echo "Quick check:         train-encoder (CEW) -> train-lint-rn15"
@@ -90,7 +91,8 @@ lint:
 type-check:
 	uv run $(EXTRAS) ty check blinklinmult
 
-# The fast gate. Skips the real Lightning training runs, ~49s of the ~85s suite. Nothing here touches the network: the whole suite passes under
+# The fast gate. Skips the real Lightning training runs, ~49s of the ~85s
+# suite. Nothing here touches the network: the whole suite passes under
 # HF_HUB_OFFLINE=1, and every model test reads the local graphs in $(ONNX_DIR).
 # `python -m tests`, not `unittest discover`. Same tests, different exit path:
 # tests/__main__.py sets the discovery root to the repo (so `demos.docker.serve`
@@ -1000,6 +1002,32 @@ push-model:
 		$(ONNX_DIR)/$(MODEL_ID) $(MODEL_ID) --repo-type model
 	HF_XET_HIGH_PERFORMANCE=1 uv run hf upload $(HF_MODEL_REPO) \
 		$(ONNX_DIR)/$(MODEL_ID).json $(MODEL_ID).json --repo-type model
+
+# Deploy the Gradio demo. The Space is the one published surface with no CI
+# behind it: nothing builds it on a push, and nothing notices when it breaks. It
+# had no deploy target at all, so its files were uploaded by hand and drifted --
+# the live app.py still read the example clip from `data/raw/`, a corpus
+# directory that does not exist on a Space, while the repo had long since moved
+# to the bundled `blinklinmult.assets` copy. This target makes the repo the
+# source of truth so that cannot happen twice.
+#
+# Uploaded one file at a time rather than as a directory: the Space keeps
+# `app.py` and `README.md` at its root, while they live under `demos/gradio/`
+# here, so each needs its destination named.
+#
+# A rebuild after this does NOT pick up a changed `python_version` on its own --
+# Hugging Face reuses the cached base image. To change the interpreter, follow
+# this with a factory reboot, which discards those layers:
+#
+#   uv run python -c "from huggingface_hub import HfApi; \
+#     HfApi().restart_space('$(HF_SPACE_REPO)', factory_reboot=True)"
+push-space:
+	HF_XET_HIGH_PERFORMANCE=1 uv run hf upload $(HF_SPACE_REPO) \
+		demos/gradio/app.py app.py --repo-type space
+	HF_XET_HIGH_PERFORMANCE=1 uv run hf upload $(HF_SPACE_REPO) \
+		demos/gradio/README.md README.md --repo-type space
+	HF_XET_HIGH_PERFORMANCE=1 uv run hf upload $(HF_SPACE_REPO) \
+		demos/gradio/requirements.txt requirements.txt --repo-type space
 
 # The model card, built from its canonical source so the GitHub docs and the Hub
 # page cannot drift.

--- a/README.md
+++ b/README.md
@@ -253,7 +253,11 @@ Upload a video, pick a model and an event-extraction rule, get an annotated vide
 make app        # http://127.0.0.1:7860
 ```
 
-Also deployed as a Hugging Face Space at [`fodorad/blink_detection`](https://huggingface.co/spaces/fodorad/blink_detection).
+Also deployed as a Hugging Face Space at [`fodorad/blink_detection`](https://huggingface.co/spaces/fodorad/blink_detection), which runs the released package rather than this checkout:
+
+```bash
+make push-space      # upload app.py, README.md and requirements.txt
+```
 
 ## Notebook
 

--- a/demos/gradio/requirements.txt
+++ b/demos/gradio/requirements.txt
@@ -1,10 +1,19 @@
 # Hugging Face Space dependencies, for ZeroGPU (zero-a10g).
 #
-# The package is installed from git rather than PyPI so the Space tracks the
-# repository directly, and the extras are named explicitly rather than relying
-# on a single [demo] extra: the Space needs the preprocessing stack (which the
-# library treats as optional) and the ONNX runtime (likewise), and a missing one
-# fails at the first upload rather than at build time.
+# **Pinned to a released version, not a git ref.** This previously read
+# `blinklinmult[...] @ git+https://github.com/fodorad/BlinkLinMulT`, with no ref,
+# so pip resolved it to whatever `main` happened to point at. Hugging Face
+# decides when to rebuild -- we do not -- so a rebuild silently shipped whatever
+# was on `main` at that moment. That is exactly how the Space broke: a rebuild
+# picked up a commit whose `requires-python` the builder's Python could not
+# satisfy, and the Space sat in BUILD_ERROR. A version pin makes the Space run
+# the artifact that was actually released and tested, and makes an upgrade a
+# deliberate edit to this file.
+#
+# The extras are named explicitly rather than relying on a single [demo] extra:
+# the Space needs the preprocessing stack (which the library treats as optional)
+# and the ONNX runtime (likewise), and a missing one fails at the first upload
+# rather than at build time.
 #
 # `preprocess` pulls exordium, which supplies every model the pipeline runs per
 # frame: YOLO11 face detection, 6DRepNet head pose, FaceMesh 478 landmarks and
@@ -12,7 +21,10 @@
 #
 # `onnx` supplies onnxruntime, which runs the three frozen 1.x graphs. Without
 # it only `blinkcnn` would load.
-blinklinmult[preprocess,onnx] @ git+https://github.com/fodorad/BlinkLinMulT
+#
+# The model weights are NOT pinned here: they download from the public Hub repo
+# `fodorad/blink_detection` on first use and are cached by the Space.
+blinklinmult[preprocess,onnx]==2.0.0
 gradio
 matplotlib
 


### PR DESCRIPTION
The Space has been in BUILD_ERROR since 2026-09-05. Its requirements installed
the package from git with no ref, so pip resolved whatever main pointed at, and
a Hugging Face rebuild picked up a commit the builder Python could not satisfy:
"Package blinklinmult requires a different Python: 3.10.13 not in >=3.11".

Pin to blinklinmult[preprocess,onnx]==2.0.0. Rebuilds are triggered by Hugging
Face, not by us, so an unpinned git install ships whatever main holds at that
moment. A version pin makes the Space run the artifact that was released and
tested, and makes an upgrade a deliberate edit.

Add make push-space. HF_SPACE_REPO was defined but no target used it, so the
Space was updated by hand and drifted: its app.py still read the example clip
from data/raw, a corpus directory that does not exist on a Space, while the repo
had moved to the bundled blinklinmult.assets copy. The Space is the one
published surface with no CI behind it, so the repo has to be its source of
truth.