### PR TITLE
fix(deps): drop exordium[video] so pip resolves a working timm

### DIFF
--- a/demos/gradio/requirements.txt
+++ b/demos/gradio/requirements.txt
@@ -24,7 +24,22 @@
 #
 # The model weights are NOT pinned here: they download from the public Hub repo
 # `fodorad/blink_detection` on first use and are cached by the Space.
-blinklinmult[preprocess,onnx]==2.0.0
+#
+# This pin names the release that carries the exordium fix below it. Deploying
+# the Space before that release is on PyPI will fail to build -- push it after
+# the release lands, not before.
+blinklinmult[preprocess,onnx]==2.0.2
+
+# **The PyTorch path needs `linmult`.** `blinkcnn` ships as a .pt checkpoint, and
+# rebuilding it into a module goes through `blinklinmult.train.model`, which
+# imports linmult at module scope. That lives in the `train` extra, which this
+# Space does not install -- pulling Lightning, MLflow and the rest of the
+# training stack for one import is a poor trade. Naming linmult directly is the
+# smaller ask. Without it, selecting `blinkcnn` fails with
+# `ModuleNotFoundError: No module named 'linmult'` while the three ONNX models
+# still work, so the Space looks half-broken rather than broken.
+linmult>=2.1
+
 gradio
 matplotlib
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,17 @@ preprocess = [
   # >=2.11.1 removed exordium's own dependency on blinklinmult (its 1.x
   # DenseNet121 wrapper). Below that, importing exordium.video.face raises
   # ModuleNotFoundError against a v2 checkout, which has no blinklinmult.models.
-  "exordium[video]>=2.11.1",
+  # **Not `exordium[video]`.** That extra pulls `unigaze`, which hard-pins
+  # `timm==0.3.2` -- a 2021 release importing `torch._six`, removed in torch 2.x.
+  # Locally `[tool.uv] override-dependencies` forces timm>=1.0 and hides this,
+  # but pip ignores that section, so a pip install (a Hugging Face Space, a
+  # Dockerfile) silently gets the broken timm and every exordium import fails
+  # with `No module named 'torch._six'`. Nothing here uses unigaze, so the four
+  # `[video]` packages that ARE used are named directly instead.
+  "exordium>=2.11.1",
+  "einops",
+  "timm>=1.0",
+  "ultralytics",
   # **Pinned below 1.0.** mediapipe 1.0.x aborts the process inside
   # `TensorsToDetectionsCalculator::Open` -- "Check failed: service_ Service is
   # unavailable" -- on macOS arm64 / Python 3.13, for any input including a

--- a/uv.lock
+++ b/uv.lock
@@ -304,23 +304,6 @@ wheels = [
 ]
 
 [[package]]
-name = "av"
-version = "18.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8d/f4/f22114d30d3435e38c6af2b4870f37b864403dca6ae7af747a289ce0a18e/av-18.1.0.tar.gz", hash = "sha256:47bfc286e1bc9de7ab4681fc2b575cd2460a66919d31ffe1bd5aa54fae531a28", size = 4451061, upload-time = "2026-08-12T22:28:18.761Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/d4/d7cdc8bff143c17a6d35924375ae28dd692cacde38700a7d419fde54f44a/av-18.1.0-cp311-abi3-macosx_11_0_x86_64.whl", hash = "sha256:ae75d8bb6467895ed1f8572ededf7ffa49eac07f6e483222f5d7d62a41d12f04", size = 22546147, upload-time = "2026-08-12T22:27:11.851Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/c9/37a619297492256b77d5ed906e7d8166c10a26ed251dccf1ae03ab19bff6/av-18.1.0-cp311-abi3-macosx_14_0_arm64.whl", hash = "sha256:b30a4e8d934558e19602b68998a4d9ac9f250fa0dacef216f7e8e40153b13316", size = 18217603, upload-time = "2026-08-12T22:27:14.713Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/84/2464ffb64c08c5ce8b522c8e74594714414e3b0575267652c5c51c0574b9/av-18.1.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:6fc837cc51adf80331ac850779cd53b5d4c4460b0ebe9057a02a921c6736f19d", size = 33640142, upload-time = "2026-08-12T22:27:17.835Z" },
-    { url = "https://files.pythonhosted.org/packages/27/3a/204dbfc3e08eb4cdc6e6ff57be02150bc44523ebdb50182d10025792ebd9/av-18.1.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:8a032e8d8ebc73dec079364b9b4a6837638a2d106e8472314e685ffbf163e700", size = 35786210, upload-time = "2026-08-12T22:27:20.984Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/99/b0d04ec553ff9a7e00455458dfa3a39c8a8f627b273056b4e5fe57d590de/av-18.1.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:3c8b1f8b46f99d52e2d8b0ed5d0cdadf172d24794d46e2077b16e44ed08e26ff", size = 39379798, upload-time = "2026-08-12T22:27:24.432Z" },
-    { url = "https://files.pythonhosted.org/packages/56/b1/e00d4feae59160149df6126585e726fdc6300798fd40c5dd324879e81f68/av-18.1.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ab5ac081bc9eaf54109120d4e56284674fecfbe520d9aa1707c7fa911ec5f4d2", size = 34690321, upload-time = "2026-08-12T22:27:27.769Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/94/836fa987e3084d11a21489f11357fb24843ef3aa8faf74ddddfc603d5062/av-18.1.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:191224788d87af06c31784a395bb73f14b72f33d7f4871ace0157de2abdc6276", size = 36859932, upload-time = "2026-08-12T22:27:31.403Z" },
-    { url = "https://files.pythonhosted.org/packages/33/b4/76ba21e46704f632004276b85289a1582e95f5eff760436d6149875a1881/av-18.1.0-cp311-abi3-win_amd64.whl", hash = "sha256:ea1480b7a8d5405cb5f382b344731bf125fd2c1c6fae3964f6c48595628387ff", size = 27595679, upload-time = "2026-08-12T22:27:35.177Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/ad/a3135884c5753b09773176b97201ae602f67ad14206c395ff838d66bf9b0/av-18.1.0-cp311-abi3-win_arm64.whl", hash = "sha256:5509ec12aaa19fd6601de13cfa6f4cdad450da07982118510592875d970454d6", size = 20257584, upload-time = "2026-08-12T22:27:38.472Z" },
-]
-
-[[package]]
 name = "babel"
 version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -370,7 +353,7 @@ wheels = [
 
 [[package]]
 name = "blinklinmult"
-version = "1.0.4"
+version = "2.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },
@@ -417,10 +400,13 @@ onnx = [
     { name = "onnxruntime" },
 ]
 preprocess = [
-    { name = "exordium", extra = ["video"] },
+    { name = "einops" },
+    { name = "exordium" },
     { name = "mediapipe" },
     { name = "opencv-python" },
+    { name = "timm" },
     { name = "tqdm" },
+    { name = "ultralytics" },
 ]
 serve = [
     { name = "fastapi" },
@@ -453,7 +439,8 @@ train = [
 [package.metadata]
 requires-dist = [
     { name = "coverage", marker = "extra == 'dev'" },
-    { name = "exordium", extras = ["video"], marker = "extra == 'preprocess'", specifier = ">=2.11.1" },
+    { name = "einops", marker = "extra == 'preprocess'" },
+    { name = "exordium", marker = "extra == 'preprocess'", specifier = ">=2.11.1" },
     { name = "fastapi", marker = "extra == 'serve'" },
     { name = "furo", marker = "extra == 'docs'" },
     { name = "gradio", marker = "extra == 'demo'" },
@@ -489,6 +476,7 @@ requires-dist = [
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=8.0" },
     { name = "sphinx-autoapi", marker = "extra == 'docs'" },
     { name = "sphinx-autobuild", marker = "extra == 'docs'" },
+    { name = "timm", marker = "extra == 'preprocess'", specifier = ">=1.0" },
     { name = "timm", marker = "extra == 'torch'", specifier = ">=1.0" },
     { name = "timm", marker = "extra == 'train'", specifier = ">=1.0" },
     { name = "torch", marker = "extra == 'torch'", specifier = ">=2.12" },
@@ -500,6 +488,7 @@ requires-dist = [
     { name = "tqdm", marker = "extra == 'preprocess'" },
     { name = "tqdm", marker = "extra == 'train'" },
     { name = "ty", marker = "extra == 'dev'" },
+    { name = "ultralytics", marker = "extra == 'preprocess'" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'serve'" },
 ]
 provides-extras = ["train", "data", "onnx", "torch", "export", "compare", "serve", "demo", "preprocess", "dev", "notebooks", "docs"]
@@ -1008,16 +997,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/bf/744a8bffa9bd765b530b4410a8c705702fd65e766d7dc434ee50470b74ed/exordium-2.11.3-py3-none-any.whl", hash = "sha256:c107dbc5e45f3bee9031b5889428b0247690f1dafe45aaf51efc655a59d4a365", size = 203727, upload-time = "2026-08-09T14:47:40.184Z" },
 ]
 
-[package.optional-dependencies]
-video = [
-    { name = "einops" },
-    { name = "marlin-pytorch" },
-    { name = "mediapipe" },
-    { name = "timm" },
-    { name = "ultralytics" },
-    { name = "unigaze" },
-]
-
 [[package]]
 name = "fastapi"
 version = "0.141.1"
@@ -1041,18 +1020,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/33/a4/9473c7c3b87009d9c1d74034e4a0f6a35ff0d42dd0f9866d0c3ec4e9217b/fastjsonschema-2.22.2.tar.gz", hash = "sha256:72064e12356a7d6ef02165be2946b9abadbdf238536e07eb587e3dbaa33099cf", size = 385171, upload-time = "2026-08-15T19:47:08.853Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/82/2755c7c982086f00d4dab85bc120ec35045a9fc2191893a6ce79afe94443/fastjsonschema-2.22.2-py3-none-any.whl", hash = "sha256:0fb3915616adac85ccfdd737d26be1089845d2019819505b42d39888458f74d4", size = 27413, upload-time = "2026-08-15T19:47:04.406Z" },
-]
-
-[[package]]
-name = "ffmpeg-python"
-version = "0.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "future" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/5e/d5f9105d59c1325759d838af4e973695081fbbc97182baf73afc78dec266/ffmpeg-python-0.2.0.tar.gz", hash = "sha256:65225db34627c578ef0e11c8b1eb528bb35e024752f6f10b78c011f6f64c4127", size = 21543, upload-time = "2019-07-06T00:19:08.989Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/0c/56be52741f75bad4dc6555991fabd2e07b432d333da82c11ad701123888a/ffmpeg_python-0.2.0-py3-none-any.whl", hash = "sha256:ac441a0404e053f8b6a1113a77c0f452f1cfc62f6344a769475ffdc0f56c23c5", size = 25024, upload-time = "2019-07-06T00:19:07.215Z" },
 ]
 
 [[package]]
@@ -1221,15 +1188,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ec/20/5f5ad4da6a5a27c80f2ed2ee9aee3f9e36c66e56e21c00fde467b2f8f88f/furo-2025.12.19.tar.gz", hash = "sha256:188d1f942037d8b37cd3985b955839fea62baa1730087dc29d157677c857e2a7", size = 1661473, upload-time = "2025-12-19T17:34:40.889Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/b2/50e9b292b5cac13e9e81272c7171301abc753a60460d21505b606e15cf21/furo-2025.12.19-py3-none-any.whl", hash = "sha256:bb0ead5309f9500130665a26bee87693c41ce4dbdff864dbfb6b0dae4673d24f", size = 339262, upload-time = "2025-12-19T17:34:38.905Z" },
-]
-
-[[package]]
-name = "future"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a7/b2/4140c69c6a66432916b26158687e821ba631a4c9273c474343badf84d3ba/future-1.0.0.tar.gz", hash = "sha256:bd2968309307861edae1458a4f8a4f3598c03be43b97521076aebf5d94c07b05", size = 1228490, upload-time = "2024-02-21T11:52:38.461Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/71/ae30dadffc90b9006d77af76b393cb9dfbfc9629f339fc1574a1c52e6806/future-1.0.0-py3-none-any.whl", hash = "sha256:929292d34f5872e70396626ef385ec22355a1fae8ad29e1a734c3e43f9fbc216", size = 491326, upload-time = "2024-02-21T11:52:35.956Z" },
 ]
 
 [[package]]
@@ -2148,26 +2106,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
     { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
     { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
-]
-
-[[package]]
-name = "marlin-pytorch"
-version = "0.3.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "av" },
-    { name = "einops" },
-    { name = "ffmpeg-python" },
-    { name = "numpy" },
-    { name = "opencv-python" },
-    { name = "pyyaml" },
-    { name = "torch" },
-    { name = "torchvision" },
-    { name = "tqdm" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/00/0d/f00b78303bce133efebbd1c1d65626ec2384bbe5d88a59059676f0a78162/marlin_pytorch-0.3.4.tar.gz", hash = "sha256:ed550cd5c48d7861672d153331110a1a71c69df4a56c83ef415645fba9568855", size = 26238, upload-time = "2023-08-31T08:28:26.524Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/1f/0d9e4f266f501be0256503c99928b650b98b56486bd05c20b175e2dfc537/marlin_pytorch-0.3.4-py3-none-any.whl", hash = "sha256:7395436be563ba1e37ee04fdfd7c9b98c4fbd2721ab7f5f11d4a8c5b40503813", size = 25164, upload-time = "2023-08-31T08:28:25.315Z" },
 ]
 
 [[package]]
@@ -4542,21 +4480,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/45/20/d6b6aaa8ecf7dbdeaf0c05f73bdcd04cf8ce468d936bc48dbcd368e75baf/ultralytics_thop-2.1.6.tar.gz", hash = "sha256:0ec2df8ebd3db35795e1f80cdc8bce6734446dbe989bca1b0c89396353f0f08c", size = 36364, upload-time = "2026-07-30T22:31:28.143Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/53/98/f1fa3d40d548c8a2a3eec33b7f856063bb6c7d51e16d5198b1f390b2c79d/ultralytics_thop-2.1.6-py3-none-any.whl", hash = "sha256:23f7b8ad124fa3432c1a7de9279102c4fdda699216032a7dff49f87ec3d1a3af", size = 30479, upload-time = "2026-07-30T22:31:26.874Z" },
-]
-
-[[package]]
-name = "unigaze"
-version = "0.1.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "huggingface-hub" },
-    { name = "numpy" },
-    { name = "safetensors" },
-    { name = "timm" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/17/47/861770d6ac8628d96aae41f91cdce7380d1297efc9a4d90bbb426afb73cf/unigaze-0.1.3.tar.gz", hash = "sha256:886c1bcbed1f22bfa66a23761e218dab7c443e4fe31a3fa2b752e31bc29dc0db", size = 16940, upload-time = "2025-11-25T12:21:51.772Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/45/3f18355876d7a6f1b14e01481657aa3921db3e703f19aaa290f6d92e99f0/unigaze-0.1.3-py3-none-any.whl", hash = "sha256:a3f4101ac105d56f0e23e7ee9bd1981304c43b6677073231fd6140e184aefa7d", size = 16413, upload-time = "2025-11-25T12:21:50.634Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The Hugging Face Space failed every analysis with FeatureError: automatic eye
localisation needs exordium, "No module named torch._six".

exordium[video] pulls unigaze, which hard-pins timm==0.3.2 -- a 2021 release
importing torch._six, removed in torch 2.x. Locally [tool.uv]
override-dependencies forces timm>=1.0 and hides this, but pip ignores that
section, so any pip install (a Space, a Dockerfile) silently got the broken timm
and every exordium import died.

Nothing here uses unigaze, so name the four [video] packages that are actually
used -- einops, timm, ultralytics, and the already-pinned mediapipe -- and drop
the extra. Verified with a real pip install: timm 1.0.29, exordium imports, no
unigaze.

Also add linmult to the Space requirements. blinkcnn ships as a .pt checkpoint
whose load path imports blinklinmult.train.model, which imports linmult at
module scope; that lives in the train extra the Space does not install, so
selecting blinkcnn failed while the three ONNX models worked.